### PR TITLE
Made name of metadata change along with name of pointcloud map

### DIFF
--- a/autoware_launch/launch/components/tier4_map_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_map_component.launch.xml
@@ -2,7 +2,7 @@
 <launch>
   <include file="$(find-pkg-share tier4_map_launch)/launch/map.launch.xml">
     <arg name="pointcloud_map_path" value="$(var map_path)/$(var pointcloud_map_file)"/>
-    <arg name="pointcloud_map_metadata_path" value="$(var map_path)/pointcloud_map_metadata.yaml"/>
+    <arg name="pointcloud_map_metadata_path" value="$(var map_path)/$(var pointcloud_map_file)_metadata.yaml"/>
     <arg name="lanelet2_map_path" value="$(var map_path)/$(var lanelet2_map_file)"/>
     <arg name="map_projector_info_path" value="$(var map_path)/map_projector_info.yaml"/>
 


### PR DESCRIPTION
I am thinking to make the filename of pointcloud_map_metadata.yaml - file that defines displacement of each divided map - flexible so that we can easily switch a series of divided maps among many. 

For this, I pushed a modification on dev/divided_map of autoware_launch.FTD.

Please merge this if you think this is good to go.
This modification is already tested and working fine on Okinawa testbed.

**Note**: Confirm the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/) before submitting a pull request.

Click the `Preview` tab and select a PR template:

- [Standard change](?expand=1&template=standard-change.md)
- [Small change](?expand=1&template=small-change.md)

**Do NOT send a PR with this description.**
